### PR TITLE
change the makefile to make it compatible with non-GNU make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,19 @@
 CC = cc
 DRVFLAGS = -DDRV_OGL -DDRV
 CFLAGS = $(DRVFLAGS) -g -O0
-LDFLAGS = -lm -lGL -lGLU -lglut
+LDFLAGS = -lm -lglut -lGL -lGLU -lX11 -lXmu
 
-DRV_SRC = drv_ogl.c
-#DRV_SRC = drv_pgc.c
-#DRV_SRC = drv_xgl.c
-#DRV_SRC = drv_igl.c
-#DRV_SRC = drv_phg.c
+DRV_OBJ = drv_ogl.o
+#DRV_SRC = drv_pgc.o
+#DRV_SRC = drv_xgl.o
+#DRV_SRC = drv_igl.o
+#DRV_SRC = drv_phg.o
 
-SOURCES = drv.c $(DRV_SRC) err.c globe.c main.c
-OBJECTS = $(SOURCES:.c=.o)
+OBJECTS = drv.o $(DRV_OBJ) err.o globe.o main.o
 TARGET = testglobe
 
 $(TARGET) : $(OBJECTS)
-	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+	$(CC) -o $@ $(OBJECTS) $(LDFLAGS)
 
 clean:
 	@rm -f $(TARGET) $(OBJECTS) core


### PR DESCRIPTION
Changed the makefile to work with non-GNU make, like the SGI make utility or any other POSIX makefile.

Also changed the order of libraries passed to the linker to work correctly with the SGI linker, and added some missing libraries necessary due to the SGI GLUT being a static library and not pulling the Xlib dependencies in automatically.