### PR TITLE
fix build on IRIX and add some improvements (mainly display lists)

### DIFF
--- a/globe.c
+++ b/globe.c
@@ -96,7 +96,7 @@ int globe_alloc(void)
     return 1;
 }
 
-inline void lookup_color()
+void lookup_color()
 {
     
 }


### PR DESCRIPTION
To build on IRIX:
 - dropped inline from a couple of functions. Could be added back in with an ifdef if necessary.
 - changed glutKeyboardUpFunc to glutKeyboardFunc: that's not strictly necessary, but the Up callback here is entirely unnecessary and narrows compatibility with GLUT versions, since it's only available from 3.7 and on.

Improvements:
 - rendering with a display list.
 - use double-buffering and ask for an RGB visual.
 - move state setup code to init instead of doing it every frame.
 - dropped the unnecessary loop in ogl_checkerrors.